### PR TITLE
Add new heat map coloring strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "simply-blame" extension will be documented in this file.
 
+## [1.2.0]
+### Add
+ - Add new heat map coloring strategy
+
 ## [1.1.0]
 ### Add
  - Add support for shorter date formats.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simply-blame",
-  "version": "0.0.12",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simply-blame",
-      "version": "0.0.12",
+      "version": "1.2.0",
       "devDependencies": {
         "@types/glob": "^8.0.0",
         "@types/mocha": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -46,9 +46,18 @@
           "default": "system",
           "description": "Date format for git blame."
         },
+        "simplyblame.heatColorIndexStrategy": {
+          "type": "string",
+          "default": "scale",
+          "description": "Defines how the heat of the blame annotations are shown.",
+          "enum": [
+            "scale",
+            "highlight"
+          ]
+        },
         "simplyblame.heatMapColorsDark": {
           "type": "array",
-          "maxItems": 11,
+          "minItems": 6,
           "pattern": "^#[a-fA-F0-9]{6}",
           "default": [
             "#990000",
@@ -67,7 +76,7 @@
         },
         "simplyblame.heatMapColorsLight": {
           "type": "array",
-          "maxItems": 11,
+          "minItems": 6,
           "pattern": "^#[a-fA-F0-9]{6}",
           "default": [
             "#ffcccc",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Simply Blame",
   "description": "Idea like git blame annotations",
   "publisher": "JamiTech",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "repository": {
     "type": "github",
     "url": "https://github.com/JamiLu/simply-blame"

--- a/src/HeatMapManager.ts
+++ b/src/HeatMapManager.ts
@@ -1,5 +1,4 @@
-import * as vscode from 'vscode';
-import { IndexedHeatMap, getHeatColor as getColor, indexHeatColors } from './HeatMap';
+import { IndexedHeatMap, indexHeatColors } from './HeatMap';
 import { BlamedDate, BlamedDocument } from './Blame';
 import { isDarkTheme } from './Utils';
 import Settings from './Settings';
@@ -19,7 +18,7 @@ class HeatMapManager {
     }
 
     getHeatColor(date: BlamedDate) {
-        return getColor(date, this.heatMap, this.heatColors);
+        return this.heatMap[date.dateString] || this.heatColors.at(-1);
     }
 
     refreshColors() {

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -20,6 +20,10 @@ class Settings {
     static getDateFormat(): string {
         return vscode.workspace.getConfiguration(this.conf).dateFormat;
     }
+
+    static getHeatColorIndexStrategy(): 'scale' | 'highlight' {
+        return vscode.workspace.getConfiguration(this.conf).heatColorIndexStrategy;
+    }
 }
 
 export default Settings;

--- a/src/test/suite/HeatMap.test.ts
+++ b/src/test/suite/HeatMap.test.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode';
 import * as assert from 'assert';
 import * as mocha from 'mocha';
 import * as sinon from 'sinon';
@@ -9,13 +10,36 @@ import { getBlame } from './Blame.test';
 
 suite('Test HeatMap', () => {
 
-    const heatColors = Settings.getHeatMapColors();
+    const heatColors = [
+        "#990000",
+        "#910808",
+        "#8a0f0f",
+        "#821717",
+        "#7a1f1f",
+        "#732626",
+        "#6b2e2e",
+        "#633636",
+        "#5c3d3d",
+        "#544545",
+        "#382e2e"
+    ];
+
+    let strategyStub: sinon.SinonStub;
 
     mocha.before(async () => {
         await activateExtension();
     });
 
-    test('test heatmap generation', async () => {
+    mocha.beforeEach(() => {
+        strategyStub = sinon.stub(Settings, 'getHeatColorIndexStrategy');
+    });
+
+    mocha.afterEach(() => {
+        strategyStub.restore();
+    });
+
+    test('test heatmap generation highlight strategy', async () => {
+        strategyStub.returns('highlight');
         const blameFileStub = sinon.stub(blameMock, 'blameFile').returns(Promise.resolve(getBlame()));
 
         const blamed = await blameMock.blame(document);
@@ -48,17 +72,40 @@ suite('Test HeatMap', () => {
         };
     };
 
-    test('test heatmap max color generation', () => {
+    const createMockBlamedDocument = () => {
         const date = new Date(2024, 0, 30); // Jan 30 2024
         const blamed: blameMock.BlamedDocument[] = [];
         for (let i = 25; i > 10; i--) {
             date.setDate(i);
             blamed.push(createMockBlame(i, date));
         }
+        return blamed;
+    };
+
+    test('test heatmap max color generation highlight strategy', () => {
+        strategyStub.returns('highlight');
+        const blamed = createMockBlamedDocument();
 
         const heatMap = heatMapMock.indexHeatColors(blamed, heatColors);
 
         assert.strictEqual(15, blamed.length);
         assert.strictEqual(11, Object.keys(heatMap).length);
+    });
+
+    test('test heatmap max color generation scale strategy', () => {
+        strategyStub.returns('scale');
+        const blamed = createMockBlamedDocument();
+
+        const heatMap = heatMapMock.indexHeatColors(blamed, heatColors);
+        const distinctColors = Object.values(heatMap).reduce((prev: string[] | vscode.ThemeColor[], cur: string | vscode.ThemeColor) => {
+            if (!prev.includes(cur as string)) {
+                prev.push(cur as string);
+            }
+            return prev;
+        }, []);
+
+        assert.strictEqual(15, blamed.length);
+        assert.strictEqual(15, Object.keys(heatMap).length);
+        assert.strictEqual(11, distinctColors.length);
     });
 });


### PR DESCRIPTION
Add new heat map coloring strategy scale in addition to the original highlight strategy. The scale strategy colors equally through out all of the commits on the file where as the highlight strategy behaves as the original coloring strategy. The highlight strategy highlights the latest commits on the file.

Remove the heat map max color limit.