### PR TITLE
Add an empty annotation on edited lines in the text editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "simply-blame" extension will be documented in this file.
 
+## [1.4.4]
+### Update
+ - Add empty annotation on edited lines in the text editor
+
 ## [1.4.3]
 ### Update
  - Update README

--- a/src/BlameManager.ts
+++ b/src/BlameManager.ts
@@ -121,7 +121,7 @@ ${content}
     private createDecorations(lineIdx: number, contentLineDefaultLength: number): BlameDecoration {
         const blamedDocument = this.blamedDocument[lineIdx];
 
-        if (blamedDocument && blamedDocument.hash !== '0') {
+        if (blamedDocument?.hash !== '0') {
             return [
                 {
                     contentText: `\u2003${blamedDocument.author.displayName}`,

--- a/src/BlameManager.ts
+++ b/src/BlameManager.ts
@@ -46,7 +46,7 @@ class BlameManager {
                 .reduce((prev, curr) => prev > curr ? prev : curr, 0);
         
             if (this.blamedDocument.length > 0) {
-                this.heatMapManager.indexHeatMap(this.blamedDocument.filter(l => l.hash !== '0'));
+                this.heatMapManager.indexHeatMap(this.blamedDocument);
 
                 const [name, date] = this.getBlamedDecorations(editor.document, true);
                 editor.setDecorations(this.nameRoot, name);

--- a/src/Date.ts
+++ b/src/Date.ts
@@ -7,7 +7,7 @@ export const prependZero = (num: number): string => {
     return num < 10 ? `0${num}` : `${num}`;
 };
 
-const prependSpace = (date: string) => {
+export const prependSpace = (date: string) => {
     return date.padStart(10 - date.length + date.length, '\u2007');
 };
 

--- a/src/ExtensionManager.ts
+++ b/src/ExtensionManager.ts
@@ -46,8 +46,10 @@ class ExtensionManager {
             this.blameManager.refresh();
         });
 
-        vscode.workspace.onDidChangeTextDocument(() => {
-            this.blameManager.refresh();
+        vscode.workspace.onDidChangeTextDocument((event) => {
+            if (event.document.isDirty) {
+                this.blameManager.refresh(event);
+            }
         });
 
         this.context.subscriptions.push(debugCommand, blameCommand, copyHashCommand);

--- a/src/HeatMap.ts
+++ b/src/HeatMap.ts
@@ -26,7 +26,7 @@ const toDistinctDates = (prev: BlamedDate[], curr: BlamedDate) => {
 
 export const indexHeatColors = (blamedDocument: BlamedDocument[], heatColors: string[]): IndexedHeatMap => {
     const distinctDates = blamedDocument
-        .filter(Boolean)
+        .filter(doc => doc.hash !== '0')
         .map((doc) => doc.date)
         .reduce(toDistinctDates, [] as BlamedDate[]);
 		


### PR DESCRIPTION
Add an empty annotation on edited lines in the text editor. This will fix the issue of the blame annotations not following the correct lines during the file is being edited.