### PR TITLE
Make hover annotations default to normal

### DIFF
--- a/src/DecorationManager.ts
+++ b/src/DecorationManager.ts
@@ -28,6 +28,7 @@ class DecorationManager {
 
     public refresh() {
         switch (Settings.getHoverStyle()) {
+            default:
             case 'normal':
                 this.createHoverMessage = this.createNormalMessage;
                 break;


### PR DESCRIPTION
Make hover annotations default to normal in case of the hover style is undefined after updating the extension as the new settings might have not reloaded by adding the default keyword into the switch case.