### PR TITLE
Fix dirty lines annotation issue

### DIFF
--- a/src/BlameManager.ts
+++ b/src/BlameManager.ts
@@ -118,7 +118,7 @@ ${content}
                 const range = line.range;
 
                 if (fresh && line.text.trim() !== this.blamedDocument[i]?.codeline.trim()) {
-                    this.blamedDocument.splice(i, 0, { hash: '0' } as BlamedDocument);
+                    this.blamedDocument.splice(i, 1, { hash: '0' } as BlamedDocument);
                 }
 
                 const [name, date] = this.decorationManager.getDecorationOptions(range, this.blamedDocument[i]);


### PR DESCRIPTION
Fix an issue blame annotations were cleared for the lines after the dirty line. That was caused by not replacing the dirty line but appending to the array.