### PR TITLE
Show a warning message when file is not found in git HEAD

### DIFF
--- a/src/Git.ts
+++ b/src/Git.ts
@@ -25,7 +25,9 @@ export const blameFile = async (fileName: string): Promise<string> => {
     try {
         return await command(`cd ${location} && git blame --porcelain ${name}`) ?? '';
     } catch (e) {
-        if ((e as Error).message.match(/git\:?\s*(not found)?/)) {
+        if ((e as Error).message.match(/no such path .* in HEAD/)) {
+            vscode.window.showWarningMessage(`File: ${name} is not in HEAD`);
+        } else if ((e as Error).message.match(/git\:?\s*(not found)?/)) {
             Notifications.gitNotFoundNotification();
         } else {
             Notifications.commonErrorNotification(e as Error, true);

--- a/src/test/suite/Git.test.ts
+++ b/src/test/suite/Git.test.ts
@@ -1,6 +1,7 @@
 /**
  * License GPL-2.0
  */
+import * as vscode from 'vscode';
 import * as mocha from 'mocha';
 import * as sinon from 'sinon';
 import * as assert from 'assert';
@@ -83,6 +84,17 @@ Maybe this commit message is long and descriptive enough to prove a point.
         await blameFile('test.txt');
 
         assert.ok(commonErrorSpy.calledOnce);
+    });
+
+    test('test blameFile shows a warning message when path is not in HEAD', async () => {
+        const showWarningMessage = sinon.stub(vscode.window, 'showWarningMessage');
+
+        commandStub.throwsException(new Error('fatal: no such path dev/index.ts in HEAD'));
+
+        await blameFile('index.ts');
+
+        assert.ok(showWarningMessage.calledOnce);
+        showWarningMessage.restore();
     });
 
     test('test blameFile slash succeeds', async () => {      


### PR DESCRIPTION
Show a warning message to user when the blame is opened for the git ignored files or files that are not in git HEAD