### PR TITLE
Fixes & improvements

### DIFF
--- a/src/Blame.ts
+++ b/src/Blame.ts
@@ -83,6 +83,7 @@ export const blame = async (document: vscode.TextDocument): Promise<BlamedDocume
                 summary: '',
                 filename: '',
             });
+            lastLine = 'init';
         } else if (parsed.length > 0) {
             const entry = parsed.at(-1)!;
 
@@ -112,7 +113,7 @@ export const blame = async (document: vscode.TextDocument): Promise<BlamedDocume
                 entry.filename = filename;
                 authors[entry.hash] = entry;
                 lastLine = 'filename';
-            } else if (line.length > 0 && authors[entry.hash]) {
+            } else if (line.length > 0 && authors[entry.hash] && (lastLine === 'init' || lastLine === 'filename')) {
                 const info = authors[entry.hash];
                 entry.author = info.author;
                 entry.email = info.email;

--- a/src/BlameHoverProvider.ts
+++ b/src/BlameHoverProvider.ts
@@ -9,7 +9,7 @@ import Settings from './Settings';
 import { ZERO_HASH } from './Blame';
 
 interface HoverCreator {
-    createHover(document: vscode.TextDocument, position: vscode.Position, blameManager: BlameManager): Promise<vscode.Hover>
+    createHover(document: vscode.TextDocument, position: vscode.Position, blameManager: BlameManager): Promise<vscode.Hover> | undefined
 }
 
 class BlameHoverProvider implements vscode.HoverProvider {
@@ -22,6 +22,7 @@ class BlameHoverProvider implements vscode.HoverProvider {
         this.blameManager = blameManager;
         this.hoverCreators = [new NormalHoverCreator(), new MinimalHoverCreator()];
         this.hoverCreator = this.hoverCreators[0];
+        this.refresh();
     }
 
     refresh() {
@@ -47,9 +48,12 @@ export default BlameHoverProvider;
 
 class MinimalHoverCreator implements HoverCreator {
 
-    createHover(document: vscode.TextDocument, position: vscode.Position, blameManager: BlameManager): Promise<vscode.Hover> {
+    createHover(document: vscode.TextDocument, position: vscode.Position, blameManager: BlameManager): Promise<vscode.Hover> | undefined  {
         const blame = blameManager.getBlameAt(position.line);
-        return Promise.resolve(new vscode.Hover(createMinimalMessage(blame), document.lineAt(position.line).range));
+
+        if (blame.hash !== '0') {
+            return Promise.resolve(new vscode.Hover(createMinimalMessage(blame), document.lineAt(position.line).range));
+        }
     }
 
 }

--- a/src/HashAction.ts
+++ b/src/HashAction.ts
@@ -6,7 +6,7 @@ import Settings from './Settings';
 import { log } from './Logger';
 import Notifications from './Notifications';
 
-let remoteAddress: vscode.Uri;
+let remoteAddress: string;
 
 const findGitFolder = async (uri: vscode.Uri | undefined): Promise<vscode.Uri | undefined> => {
     if (uri) {
@@ -44,19 +44,16 @@ const resolveRemote = async (hash: string) => {
 
     if (!uri) {
         throw new Error('Remote url could not be resolved');
-    }
-
-    let remote = undefined;
+    }    
 
     if (uri.startsWith('git@')) {
-        remote = `https://${uri.replace('git@', '').replace(':', '/').replace('.git', '')}`;
+        remoteAddress = `https://${uri.replace('git@', '').replace(':', '/').replace('.git', '')}`;
     } else {
-        remote = uri.replace('.git', '');
+        remoteAddress = uri.replace('.git', '');
     }
     
-    log.debug(`Parsed remote address: ${remote}`);
+    log.debug(`Parsed remote address: ${remoteAddress}`);
 
-    remoteAddress = vscode.Uri.parse(`${remote}/commit/${hash}`);
     return remoteAddress;
 };
 
@@ -65,7 +62,7 @@ export const hashAction = async (hash: string) => {
     switch (action) {
         case 'remote':
             try {
-                await vscode.env.openExternal(remoteAddress ?? await resolveRemote(hash));
+                await vscode.env.openExternal(vscode.Uri.parse(`${remoteAddress ?? await resolveRemote(hash)}/commit/${hash}`));
             } catch (e) {
                 Notifications.commonErrorNotification(e as Error, true);
             }


### PR DESCRIPTION
* Fix & improve blame parsing
* Fix minimal hover box shown on empty commit
* Fix hash action reolve remote address 1/2

Blame was not correct parsed. A filename and a summary was missed from the parsed blame info. Minimal hover box was shown for an empty commit. A check was added to prevent opening the hover box for an empty commit. HashAction did not open correctly the resolved remote address. Now resolve remote supports finding the git config from the workspace root or from the first sub applicable sub folder. This still does not support multiple git repositories under one workspace.