### PR TITLE
Feature keep blame open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "simply-blame" extension will be documented in this file.
 
+## [1.10.0]
+ ### Add
+  - Keep blames open as long as the window or tab is open.
+
 ## [1.9.6]
  ### Update
   - Improve dirty line blame annotation handling

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Idea like git blame annotations for VS Code!
    * Select an action to be invoked when the commit hash is clicked on the hover box. Supported actions are copy to clipboard and open in browser.
 * **Heat Color Index Strategy**
    * Choose how the heat colors are shown. Scale through the commits, this is the default or highlight the latest commits.
+* **Keep Blames Open**
+   * Keep blame annotations open as long as a tab or window is open. If not selected annotations are closed on tab change.
 * **Use RGBColor**
    * If selected the RGBColors dark and light lists are used. This is the default.
    * Otherwise the hex color list will be used.

--- a/package.json
+++ b/package.json
@@ -90,6 +90,12 @@
           "description": "Select a hover message style for the blame annotations.",
           "order": 1
         },
+        "simplyblame.keepBlamesOpen": {
+          "type": "boolean",
+          "default": false,
+          "description": "Keep blame annotations open as long as a tab or window is open. If not selected annotations are closed on tab change.",
+          "order": 2
+        },
         "simplyblame.hashAction": {
           "type": "string",
           "enum": [

--- a/src/BlameManager.ts
+++ b/src/BlameManager.ts
@@ -5,9 +5,7 @@ import * as vscode from 'vscode';
 import { calculateDecorationsWidth, DEFAULT_WIDTH, getDecorations, LEFT_SIDE, RIGHT_SIDE } from './DecorationUtils';
 import HeatMapManager from './HeatMapManager';
 import { BlamedDate, BlamedDocument, blame, emptyBlame } from './Blame';
-import { getFilename } from './Utils';
 import ExtensionManager from './ExtensionManager';
-import { blameFile } from './Git';
 import { log } from './Logger';
 
 class BlameManager {
@@ -51,16 +49,18 @@ class BlameManager {
                     this.heatMapManager.indexHeatMap(this.blamedDocument);
                     this.applyDecorations(editor, editor.document);
                 }
+            } else {
+                this.heatMapManager.initHeatColors();
             }
-        } else {
-            this.heatMapManager.initHeatColors();
         }
     }
 
     closeBlame() {
         this.isOpen = false;
         const editor = vscode.window.activeTextEditor;
-        this.setDecorations(editor, [], []);
+        if (editor) {
+            this.setDecorations(editor, [], []);
+        }
     }
 
     getBlameAt(line: number) {
@@ -73,25 +73,6 @@ class BlameManager {
 
     get decorationWidth() {
         return this.width;
-    }
-
-    async openBlameEditor(editor: vscode.TextEditor) {
-        const blamedContent = await blameFile(editor.document.fileName);
-
-        const panel = vscode.window.createWebviewPanel('blame', `Blame - ${getFilename(editor.document.uri.path)}`, vscode.ViewColumn.Beside);
-
-        panel.webview.html = this.getHtmlForEditor(blamedContent);
-    }
-
-    private getHtmlForEditor(content: string) {
-        return `<!DOCTYPE html>
-<html>
-	<body>
-		<div style="white-space: pre">
-${content}
-		</div>
-	<body>
-</html>`;
     }
 
     private editBlamedDocument(event: vscode.TextDocumentChangeEvent) {

--- a/src/Editor.ts
+++ b/src/Editor.ts
@@ -1,0 +1,89 @@
+/**
+ * License GPL-2.0
+ */
+import * as vscode from 'vscode';
+import { blameFile } from './Git';
+import { getFilename } from './Utils';
+import BlameManager from './BlameManager';
+import Settings from './Settings';
+
+class EditorManager {
+
+    private static instance: EditorManager;
+
+    private openEditors: Map<String, BlameManager> = new Map();
+    private current: BlameManager | null = null;
+
+    private constructor() {}
+
+    get currentEditor() {
+        return this.current!;
+    }
+
+    async toggleEditor(editor: vscode.TextEditor) {
+        if (this.openEditors.get(editor.document.fileName)) {
+            await this.openEditors.get(editor.document.fileName)?.toggleBlame(editor);
+        } else {
+            const manager = new BlameManager();
+            manager.toggleBlame(editor);
+            this.openEditors.set(editor.document.fileName, manager);
+            this.current = manager;
+        }
+    }
+    
+    changeEditor(editor?: vscode.TextEditor) {
+        if (editor && !Settings.isKeepBlamesOpen()) {
+            this.closeEditor(editor.document);
+        }
+    
+        let nextEditor;
+        if ((nextEditor = editor && this.getEditor(editor.document)) !== undefined) {
+            nextEditor.refresh();
+            this.current = nextEditor;
+        }
+    }
+    
+    closeEditor(document: vscode.TextDocument) {
+        this.getEditor(document)?.closeBlame();
+    }
+    
+    disposeEditors() {
+        const iterator = this.openEditors.entries();
+        let next;
+        while ((next = iterator.next().value) !== undefined) {
+            next[1].closeBlame();
+        }
+    }
+    
+    private getEditor(document: vscode.TextDocument): BlameManager | undefined {
+        return this.openEditors.get(document.fileName);
+    }
+
+    static getInstance() {
+        if (!this.instance) {
+            this.instance = new this();
+        }
+        return this.instance;
+    }
+}
+
+export default EditorManager;
+
+export const openBlameEditor = async (editor: vscode.TextEditor) => {
+    const blamedContent = await blameFile(editor.document.fileName);
+
+    const panel = vscode.window.createWebviewPanel('blame', `Blame - ${getFilename(editor.document.uri.path)}`, vscode.ViewColumn.Beside);
+
+    panel.webview.html = getHtmlForEditor(blamedContent);
+};
+
+function getHtmlForEditor(content: string) {
+    return `<!DOCTYPE html>
+<html>
+<body>
+    <div style="white-space: pre">
+${content}
+    </div>
+<body>
+</html>`;
+};

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -61,6 +61,10 @@ class Settings {
     static getHashAction(): ('copy' | 'remote') & string {
         return vscode.workspace.getConfiguration(this.config).hashAction;
     }
+
+    static isKeepBlamesOpen(): boolean {
+        return vscode.workspace.getConfiguration(this.config).keepBlamesOpen;
+    }
     
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,11 +4,13 @@
 import * as vscode from 'vscode';
 import ExtensionManager from './ExtensionManager';
 import Logger from './Logger';
+import EditorManager from './Editor';
 
 export function activate(context: vscode.ExtensionContext) {
     ExtensionManager.getInstance(context).registerCommands();
 }
 
 export function deactivate() {
+    EditorManager.getInstance().disposeEditors();
     Logger.dispose();
 }

--- a/src/test/suite/Editor.test.ts
+++ b/src/test/suite/Editor.test.ts
@@ -1,0 +1,36 @@
+/**
+ * License GPL-2.0
+ */
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+import * as mocha from 'mocha';
+import { activateExtension, mockActiveEditor } from './helpers';
+import EditorManager from '../../Editor';
+
+const editorManagerInstance = EditorManager.getInstance();
+
+suite('Test Editor Manager', () => {
+
+    const activeEditorMock = mockActiveEditor();
+
+    mocha.before(async () => {
+        await activateExtension();
+    });
+
+    mocha.beforeEach(() => {
+        activeEditorMock.mock();
+    });
+
+    mocha.afterEach(() => {
+        activeEditorMock.restore();
+    });
+
+    test('test toggle blame should set current', () => {
+        assert.ok(editorManagerInstance.currentEditor === null, 'editorManager.currentEditor is not null');
+
+        editorManagerInstance.toggleEditor(vscode.window.activeTextEditor!);
+
+        assert.ok(editorManagerInstance.currentEditor !== null, 'editorManager.currentEditor is null');
+    });
+
+});

--- a/src/test/suite/HoverProvider.test.ts
+++ b/src/test/suite/HoverProvider.test.ts
@@ -9,11 +9,14 @@ import { activateExtension, createMockBlamedDocument, document } from './helpers
 import Settings from '../../Settings';
 import BlameHoverProvider from '../../BlameHoverProvider';
 import BlameManager from '../../BlameManager';
+import * as EditorManagerModule from '../../Editor';
+
+const blameManager = new BlameManager();
+sinon.stub(EditorManagerModule.default, 'getInstance').returns( ({ currentEditor: blameManager }) as EditorManagerModule.default );
 
 suite('Test Hover Provider', () => {
 
-    const blameManager = new BlameManager();
-    const hoverProvider = new BlameHoverProvider(blameManager);
+    const hoverProvider = new BlameHoverProvider();
 
     let styleStub: sinon.SinonStub;
     let mockManager: sinon.SinonMock;


### PR DESCRIPTION
Introduce the keep blame annotations open feature. The blame annotations are kept open as long as the window or the tab is open. A default setting for this is false and that means the annotations are not kept open during tab change or such operations.

List of changes:
* Add EditorManager that controls the open blame annotations
* Add settings for the feature
* Add and refactor tests for the feature
* Refactor to support the feature