### PR TITLE
Fix blame manager issue and improve annotation restoring

### DIFF
--- a/src/Editor.ts
+++ b/src/Editor.ts
@@ -32,13 +32,17 @@ class EditorManager {
     }
     
     changeEditor(editor?: vscode.TextEditor) {
+        if (!editor?.document.fileName) {
+            return;
+        }
+
         if (editor && !Settings.isKeepBlamesOpen()) {
             this.closeEditor(editor.document);
         }
     
         let nextEditor;
         if ((nextEditor = editor && this.getEditor(editor.document)) !== undefined) {
-            nextEditor.refresh();
+            nextEditor.restore();
             this.current = nextEditor;
         }
     }
@@ -55,7 +59,7 @@ class EditorManager {
         }
     }
     
-    private getEditor(document: vscode.TextDocument): BlameManager | undefined {
+    getEditor(document: vscode.TextDocument): BlameManager | undefined {
         return this.openEditors.get(document.fileName);
     }
 

--- a/src/ExtensionManager.ts
+++ b/src/ExtensionManager.ts
@@ -62,7 +62,7 @@ class ExtensionManager {
         });
 
         vscode.workspace.onDidChangeTextDocument((event) => {
-            if (event.document.isDirty) {
+            if (event.document.isDirty && this.editorManager.getEditor(event.document)) {
                 this.editorManager.currentEditor.refresh(event);
             }
         });


### PR DESCRIPTION
Fixed an issue that the blame manager tried to open a wrong blame annotations editor when a unopned editor was edited. Also improved the blame annotations restoring